### PR TITLE
Update copyright year from 2024 to 2025

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 Sora Labs
+Copyright (c) 2025 Sora Labs
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -2,7 +2,7 @@ export default function Footer() {
   return (
     <footer className="fixed bottom-0 w-full bg-sora-neutral/95 backdrop-blur-md border-t border-sora-secondary/20">
       <div className="max-w-7xl mx-auto px-4 h-14 flex items-center justify-between text-sm">
-        <div className="text-gray-800 text-sm">© 2024 sora labs</div>
+        <div className="text-gray-800 text-sm">© 2025 sora labs</div>
         <div className="flex gap-6 text-sm">
           <a
             href="/privacy"


### PR DESCRIPTION
**Title**:
Update Copyright Year from 2024 to 2025

**Description**:
This pull request updates the copyright notice from 2024 to 2025.

**Changes**:
Modified relevant files to reflect the updated year.
Verified that no additional changes were introduced.

**Testing**:
Confirmed that the changes display correctly across the site.